### PR TITLE
fix composer name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "PoetOS/moodle-mod_questionnaire",
+    "name": "poetos/moodle-mod_questionnaire",
     "type": "moodle-mod",
     "require": {
         "composer/installers": "~1.0"


### PR DESCRIPTION
The latest composer standards do now allow uppercase in composer names, this can cause issues with some more strict environments

See: https://getcomposer.org/doc/02-libraries.md