### PR TITLE
explicitly declare property for php8 compatibility

### DIFF
--- a/classes/questionnaire.php
+++ b/classes/questionnaire.php
@@ -2341,6 +2341,7 @@ class questionnaire {
             $respcols = new \stdClass();
             for ($i = 0; $i < $colnumber; $i++) {
                 $colname = 'respondentscolumn'.$i;
+                $respcols->{$colname} = new \stdClass();
                 for ($j = 0; $j < $lines; $j++) {
                     $respcols->{$colname}->respondentlink[] = $resparr[$a];
                     $a++;


### PR DESCRIPTION
resolves error `Uncaught Error: Attempt to modify property "respondentlink" on null`